### PR TITLE
Add delay randomization to avoid modbus sending multiple commands at …

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+`This folder used by Docker.`

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -1,0 +1,5 @@
+This folder contains MODBUS drivers. This is to allow the
+developer to alternatively add device drivers to the project.
+
+The configurations in this folder will override the drivers
+in @instathings\modbus-herdsman-converter project.

--- a/lib/modbus.js
+++ b/lib/modbus.js
@@ -13,9 +13,11 @@ class Modbus extends events.EventEmitter {
     this.mqtt = mqtt;
     /** @type {ModbusRTU} */
     this.modbus    = modbus;
-    this.id       = device.id;
-    this.model    = device.model;
-    this.modbusId = device.modbus_id;
+    this.id        = device.id;
+    this.model     = device.model;
+    this.modbusId  = device.modbus_id;
+    this.max_delay = device.max_delay || 99;
+    this.min_delay = device.min_delay || 1;
     //this.device = modbusHerdsmanConverters.findByModbusModel(this.model); // by BoogieBug, using the code below instead
     //this.interval = process.env.INTERVAL || 10000;
     this.interval = Math.max(device.interval || process.env.INTERVAL || 10000, 100); // 100 ms minimum
@@ -46,7 +48,7 @@ class Modbus extends events.EventEmitter {
     finally {
       if ( ! this.stop ) {
         process.nextTick(async () => {
-          await this.sleep(this.interval);
+          await this.sleep(this.interval + Math.floor( Math.random() * ( this.max_delay - this.min_delay ) + this.min_delay ));
           this.start();
         });
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinacono/modbus2mqtt",
-  "version": "1.1.5",
+  "version": "1.1.9",
   "description": "Modbus2MQTT bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When chain multiple RS485 device, it send multiple MODBUS commands out at the same time on start. This cause the timeout error.